### PR TITLE
Add link to up-to-date version of book

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Further reading
 - *Machine Learning with R, the tidyverse, and mlr* by Hefin I. Rhys, Manning Publications, 2020. See book [webpage](https://www.manning.com/books/machine-learning-with-r-the-tidyverse-and-mlr).
 - *Deep Learning with R* by François Chollet with J. J. Allaire, Manning Publications, 2018. See book [webpage](https://www.manning.com/books/deep-learning-with-r?query=deep%20learning%20with%20r).
 - *An Introduction to R for Spatial Analysis and Mapping* by Chris Brunsdon and Lex Comber, Sage, 2015. See book [webpage](https://uk.sagepub.com/en-gb/eur/an-introduction-to-r-for-spatial-analysis-and-mapping/book241031).
-- *Geocomputation with R* by Robin Lovelace, Jakub Nowosad and Jannes MuenchowSee, CRC Press, 2019. See [online book](https://bookdown.org/robinlovelace/geocompr/).
+- *Geocomputation with R* by Robin Lovelace, Jakub Nowosad and Jannes MuenchowSee, CRC Press, 2019. See [online book](https://geocompr.robinlovelace.net/).
 
 
 


### PR DESCRIPTION
Thanks for the link. The version on the bookdown site is a bit out of date so suggest linking to the up-to-date version that has various bugs fixed (I should probably update the bookdown version at some point, note to self). Great to see reproducible teaching materials!